### PR TITLE
Update raw-api-definitions

### DIFF
--- a/gen_completions/raw-api-definitions
+++ b/gen_completions/raw-api-definitions
@@ -624,6 +624,7 @@ network.upload( url, method, listener [, params], filename [, baseDirectory] [, 
 new()	CoronaPrototype
 newClass( name )	CoronaPrototype
 next( array [, index] )	global
+nil		Keyword
 numChildren	GroupObject
 numFrames	SpriteObject
 number	InputAxis


### PR DESCRIPTION
If you type nil followed by an carriage return, Corona Editor will try to replace nil with "network.setStatusListener( hostURL, listener )" thinking you are trying to do a substitution.

So trying to nil out variables ends up being a frustrating game of removing network.setStatusListener( hostURL, listener ) from each line.

By putting nil in the completions, it should leave it alone and it is a reserved keyword anyway so it would be nice to have it there.
