### PR TITLE
Added support to stored scoped functions on Go To Symbol

### DIFF
--- a/CoronaSDKLua.tmLanguage
+++ b/CoronaSDKLua.tmLanguage
@@ -18,6 +18,45 @@
 	<string>Corona SDK Lua</string>
 	<key>patterns</key>
 	<array>
+ 		<dict>
+         <key>captures</key>
+         <dict>
+            <key>1</key>
+            <dict>
+                <key>name</key>
+                <string>entity.name.function.scope.lua</string>
+            </dict>
+            <key>2</key>
+            <dict>
+               <key>name</key>
+               <string>entity.name.function.lua</string>
+            </dict>
+            <key>3</key>
+            <dict>
+               <key>name</key>
+               <string>keyword.control.lua</string>
+            </dict>
+            <key>4</key>
+            <dict>
+               <key>name</key>
+               <string>punctuation.definition.parameters.begin.lua</string>
+            </dict>
+            <key>5</key>
+            <dict>
+               <key>name</key>
+               <string>variable.parameter.function.lua</string>
+            </dict>
+            <key>6</key>
+            <dict>
+               <key>name</key>
+               <string>punctuation.definition.parameters.end.lua</string>
+            </dict>
+         </dict>
+         <key>match</key>
+         <string>\b([a-zA-Z_.:]+[.:])?([a-zA-Z_]\w*)\s*=\s*(function)\s*(\()([^)]*)(\))</string>
+         <key>name</key>
+         <string>meta.function.lua</string>
+      	</dict>
 		<dict>
 			<key>captures</key>
 			<dict>


### PR DESCRIPTION
With the actual branch this is ignored by Go To Symbol: _stored = function() end_ - this stored function isn't listed.

So I added support to stored scoped functions. Now go to symbol captures all these different kinds of function implementations:

``` lua
local stored
stored = function() end

local class = {}
local stored; class:stored = function() end

class.stored1 = function () end

local function loc(params) end

function glob(params) end
```

All of them show up after hitting Cmd+R:
![screen shot 2014-07-09 at 1 17 30 am](https://cloud.githubusercontent.com/assets/248383/3519815/06774c92-0720-11e4-8aaa-073365a31750.png)

With the actual code, these would be ignored: _stored, class:stored, class.stored1_.
