### PR TITLE
fixed issue #28

### DIFF
--- a/CoronaSDKLua.tmLanguage
+++ b/CoronaSDKLua.tmLanguage
@@ -44,7 +44,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>([ ]*[--])(?!\[\[).*$\n?</string>
+			<string>([ ]*-{2})(?!\[\[).*$\n?</string>
 			<key>name</key>
 			<string>comment.line.double-dash.lua</string>
 		</dict>

--- a/CoronaSDKLua.tmLanguage
+++ b/CoronaSDKLua.tmLanguage
@@ -44,7 +44,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>([ ]*-{2})(?!\[\[).*$\n?</string>
+			<string>([\s]*-{2})(?!\[\[).*$\n?</string>
 			<key>name</key>
 			<string>comment.line.double-dash.lua</string>
 		</dict>

--- a/CoronaSDKLua.tmLanguage
+++ b/CoronaSDKLua.tmLanguage
@@ -44,7 +44,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(--)(?!\[\[).*$\n?</string>
+			<string>([ ]*[--])(?!\[\[).*$\n?</string>
 			<key>name</key>
 			<string>comment.line.double-dash.lua</string>
 		</dict>


### PR DESCRIPTION
Fixed color not being applied on inline comment when the line has a "function" keyword inside another function.

PS: The issue was not due to having a function definition inside another function, but due to the indentation space before the "--".  