### PR TITLE
Fix: correct path and move global override

### DIFF
--- a/Corona Editor.sublime-settings
+++ b/Corona Editor.sublime-settings
@@ -40,7 +40,7 @@
  	// display.capture(displayObject[, saveToPhotoLibrary])
  	"corona_sdk_completions_strip_white_space":false,
 
- 	// Corona Editor will attempt to suggest lua files for you to import when 
+ 	// Corona Editor will attempt to suggest lua files for you to import when
  	// typing out 'require' statements. By default Corona Editor will not follow
  	// softlinks in your project structure. Set this to true to follow links, but beware
  	// it is possible to set up infinite cycles if a link to a root directory in your project
@@ -49,5 +49,10 @@
 
  	// When typing out a string Corona Editor can autosuggest files and paths. The list below filters the suggestions.
  	// Extend it with any other useful formats. The list is case insensitive.
- 	"corona_sdk_autocomplete_extensions":[".png",".jpeg",".jpg",".wav",".mp3"]
+ 	"corona_sdk_autocomplete_extensions":[".png",".jpeg",".jpg",".wav",".mp3"],
+
+ 	// set as default syntax for all Lua files
+ 	"extensions": [
+	    "lua"
+	]
 }

--- a/completions.py
+++ b/completions.py
@@ -262,7 +262,7 @@ class CoronaLabsCollector(CoronaLabs, sublime_plugin.EventListener):
         view.window().run_command("build")
 
     if view.file_name().lower().endswith(".lua") and _corona_utils.GetSetting("corona_sdk_default_new_file_to_corona_lua", default=True):
-      view.set_syntax_file("Packages/CoronaSDK-SublimeText/CoronaSDKLua.sublime-syntax")
+      view.set_syntax_file("Packages/Corona Editor/CoronaSDKLua.sublime-syntax")
 
   # When a Lua file is loaded and the "use_periods_in_completion" user preference is set,
   # add period to "auto_complete_triggers" if it's not already there.

--- a/completions.py
+++ b/completions.py
@@ -23,17 +23,6 @@ except:
 # We expose the completions to the snippets code
 CoronaCompletions = None
 
-if not os.path.isfile(os.path.join("User", "CoronaSDKLua.sublime-settings")):
-  with open(os.path.join("User", "CoronaSDKLua.sublime-settings"), "w") as f:
-    f.write("""
-{
-  "extensions":
-  [
-    "lua"
-  ]
-}
-""")
-
 #
 # Utility functions
 #


### PR DESCRIPTION
Hi,

At some point the package install location was changed from CoronaSDK-SublimeText to Corona Editor. The path hadn't been updated. 

I've also moved the writing of the setting file to the setting file itself. This has the advantage that the user can override it if they so please. However I do not think the package should be setting global settings for the user. 

