### PR TITLE
Fix syntax file loading 

### DIFF
--- a/Corona Editor.sublime-settings
+++ b/Corona Editor.sublime-settings
@@ -16,7 +16,7 @@
 	// completions disappear until you type another character.
 	"corona_sdk_complete_periods": true,
 
-	// If this is true then any new file that has not yet been saved will be 
+	// If this is true then any new file that has not yet been saved will be
 	// assumed to be a Corona Lua file
 	"corona_sdk_default_new_file_to_corona_lua": true,
 

--- a/completions.py
+++ b/completions.py
@@ -261,7 +261,7 @@ class CoronaLabsCollector(CoronaLabs, sublime_plugin.EventListener):
         view.window().run_command("build")
 
     if view.file_name().lower().endswith(".lua") and _corona_utils.GetSetting("corona_sdk_default_new_file_to_corona_lua", default=True):
-      view.set_syntax_file("Packages/Corona Editor/CoronaSDKLua.sublime-syntax")
+      view.set_syntax_file('Packages/' + _corona_utils.PACKAGE_NAME + '/CoronaSDKLua.sublime-syntax')
 
   # When a Lua file is loaded and the "use_periods_in_completion" user preference is set,
   # add period to "auto_complete_triggers" if it's not already there.

--- a/debugger.py
+++ b/debugger.py
@@ -16,8 +16,8 @@ import sys
 import socket
 import traceback
 
-if not os.path.isfile(os.path.join("User", "CoronaSDKLua.sublime-settings")):
-  with open(os.path.join("User", "CoronaSDKLua.sublime-settings"), "w") as f:
+if not os.path.isfile(os.path.join("User", "Corona Editor.sublime-settings")):
+  with open(os.path.join("User", "Corona Editor.sublime-settings"), "w") as f:
     f.write("""
 {
   "extensions":

--- a/debugger.py
+++ b/debugger.py
@@ -16,17 +16,6 @@ import sys
 import socket
 import traceback
 
-if not os.path.isfile(os.path.join("User", "Corona Editor.sublime-settings")):
-  with open(os.path.join("User", "Corona Editor.sublime-settings"), "w") as f:
-    f.write("""
-{
-  "extensions":
-  [
-    "lua"
-  ]
-}
-""")
-
 try:
   import queue  # P3
   coronaQueue = queue


### PR DESCRIPTION
This should fix the other issue in #42. Currently when running the plugin when installed from the git repository directly the directory name is CoronaSDK-SublimeText instead for Corona Editor which means the syntax file cannot be found. 